### PR TITLE
style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,3 +39,8 @@ a {
     color: #333;
 }
 a:hover { text-decoration: none }
+
+/* Remove Chrome Input Field's Unwanted Yellow Background Color */
+input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:focus {
+    -webkit-box-shadow: 0 0 0px 1000px white inset !important;
+}


### PR DESCRIPTION
Chrome has a bug from 2008 that it shows yellow background color in input fields on focus which is really unwanted. This trick can help removing that yellow color or you can add any color according to your wish by changing it from "white" to any other color. Alongside Chrome it will work on any browser which runs with -webkit